### PR TITLE
Release 1.2.3

### DIFF
--- a/Classes/Service/GlobalVariableProviders/EarlyAccessConstantsProvider.php
+++ b/Classes/Service/GlobalVariableProviders/EarlyAccessConstantsProvider.php
@@ -62,18 +62,20 @@ class EarlyAccessConstantsProvider extends AbstractProvider
         $contextParts = explode('/', Environment::getContext()->__toString());
         $lastIndex = count($contextParts) - 1;
         $contextParts[$lastIndex] = lcfirst($contextParts[$lastIndex]);
-        $filePath = self::DIRECTORY . implode('/', $contextParts) . '.yaml';
+        $contextSpecificFilePath = self::DIRECTORY . implode('/', $contextParts) . '.yaml';
 
         foreach ($allExtensionInformation as $extensionInformation) {
-            $yamlFile = GeneralUtility::getFileAbsFileName('EXT:' . $extensionInformation->getExtensionKey() . $filePath);
+            $basePath = 'EXT:' . $extensionInformation->getExtensionKey();
+            $yamlFiles = [
+                GeneralUtility::getFileAbsFileName($basePath . self::DIRECTORY . 'constants.yaml'),
+                GeneralUtility::getFileAbsFileName($basePath . $contextSpecificFilePath),
+            ];
 
-            if (!file_exists($yamlFile)) {
-                $yamlFile = GeneralUtility::getFileAbsFileName('EXT:' . $extensionInformation->getExtensionKey() . self::DIRECTORY . 'constants.yaml');
-            }
-
-            if (file_exists($yamlFile)) {
-                $constants = Yaml::parseFile($yamlFile) ?? [];
-                ArrayUtility::mergeRecursiveWithOverrule($mergedConstants, $constants);
+            foreach ($yamlFiles as $yamlFile) {
+                if (file_exists($yamlFile)) {
+                    $constants = Yaml::parseFile($yamlFile) ?? [];
+                    ArrayUtility::mergeRecursiveWithOverrule($mergedConstants, $constants);
+                }
             }
         }
 

--- a/Classes/Utility/ContextUtility.php
+++ b/Classes/Utility/ContextUtility.php
@@ -109,7 +109,7 @@ class ContextUtility
      */
     public static function isTypoScriptAvailable(): bool
     {
-        if (null !== $GLOBALS['TSFE'] && self::isFrontend()) {
+        if (isset($GLOBALS['TSFE']) && self::isFrontend()) {
             return true;
         }
 

--- a/Classes/Utility/TypoScript/TypoScriptUtility.php
+++ b/Classes/Utility/TypoScript/TypoScriptUtility.php
@@ -102,7 +102,7 @@ class TypoScriptUtility
                 [
                     'userFunc' => $pageTypeConfiguration->getUserFunc(),
                 ],
-                $pageTypeConfiguration->getUserFuncParameters()
+                $pageTypeConfiguration->getUserFuncParameters(),
             );
         } else {
             $contentConfiguration = [
@@ -127,7 +127,7 @@ class TypoScriptUtility
         $contentConfiguration[self::TYPO_SCRIPT_KEYS['OBJECT_TYPE']] = $internalContentType;
 
         $typoScript = [
-            self::TYPO_SCRIPT_KEYS['CONDITION']               => 'request.getQueryParams()[\'type\'] == ' . $pageTypeConfiguration->getTypeNum(),
+            self::TYPO_SCRIPT_KEYS['CONDITION']               => $pageTypeConfiguration->getTypeNum() . ' == traverse(request.getQueryParams(), \'type\')',
             $pageTypeConfiguration->getTypoScriptObjectName() => [
                 self::TYPO_SCRIPT_KEYS['OBJECT_TYPE'] => 'PAGE',
                 10                                    => $contentConfiguration,
@@ -160,7 +160,7 @@ class TypoScriptUtility
     public static function registerTypoScript(
         ExtensionInformationInterface $extensionInformation,
         string $path,
-        string $title
+        string $title,
     ): void {
         ExtensionManagementUtility::addStaticFile($extensionInformation->getExtensionKey(), $path, $title);
     }

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -48,7 +48,7 @@ class TranslateViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelp
     public static function renderStatic(
         array $arguments,
         Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
+        RenderingContextInterface $renderingContext,
     ): ?string {
         [
             'arguments'     => $translateArguments,
@@ -77,16 +77,16 @@ class TranslateViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelp
         try {
             $value = static::translate($id, $extensionName, $translateArguments, $arguments['languageKey'],
                 $arguments['alternativeLanguageKeys']);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $value = null;
         }
 
         if (null === $value) {
             $value = $default ?? $renderChildrenClosure();
+        }
 
-            if (!empty($translateArguments)) {
-                $value = vsprintf($value, $translateArguments);
-            }
+        if (null !== $value && !empty($translateArguments)) {
+            $value = vsprintf($value, $translateArguments);
         }
 
         return $value;
@@ -110,7 +110,7 @@ class TranslateViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelp
         $extensionName,
         $arguments,
         $languageKey,
-        $alternativeLanguageKeys
+        $alternativeLanguageKeys,
     ): ?string {
         return GeneralUtility::makeInstance(LocalizationService::class)
             ->translate($id, $extensionName, $arguments, $languageKey, $alternativeLanguageKeys);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,5 +18,5 @@ $EM_CONF[$_EXTKEY] = [
     'description'      => 'Configuration framework for TYPO3 extension development',
     'state'            => 'stable',
     'title'            => 'PSbits | Foundation',
-    'version'          => '1.2.2',
+    'version'          => '1.2.3',
 ];


### PR DESCRIPTION
[TASK] Set version to 1.2.3.
[BUGFIX] Apply translation arguments only when a translation exists.
[BUGFIX] Fix "undefined array key" in TypoScript condition for page types.
[BUGFIX] Fix "undefined array key" when checking if TypoScript is available in contexts other than Frontend.
[BUGFIX] Load general EarlyAccessConstants also when there is a context specific file.